### PR TITLE
fix: C4715 in operator new

### DIFF
--- a/include/RE/M/MemoryManager.h
+++ b/include/RE/M/MemoryManager.h
@@ -400,19 +400,19 @@ namespace RE
 	[[nodiscard]] void* operator new(std::size_t a_count)                 \
 	{                                                                     \
 		const auto mem = RE::malloc(a_count);                             \
-		if (mem)                                                          \
-			return mem;                                                   \
+		if (!mem)                                                         \
+			REX::FAIL("out of memory");                                   \
                                                                           \
-		REX::FAIL("out of memory");                                       \
+        return mem;                                                       \
 	}                                                                     \
                                                                           \
 	[[nodiscard]] void* operator new[](std::size_t a_count)               \
 	{                                                                     \
 		const auto mem = RE::malloc(a_count);                             \
-		if (mem)                                                          \
-			return mem;                                                   \
+		if (!mem)                                                         \
+			REX::FAIL("out of memory");                                   \
                                                                           \
-		REX::FAIL("out of memory");                                       \
+		return mem;                                                       \
 	}                                                                     \
                                                                           \
 	void operator delete(void* a_ptr) { RE::free(a_ptr); }                \


### PR DESCRIPTION
should always return a value, even on fail